### PR TITLE
Fix localization initialization for startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'core/app_context.dart';
 import 'core/app_flavor.dart';
 import 'core/app_initializer.dart';
 import 'core/app_router.dart';
+import 'l10n/gen_l10n/app_localizations.dart';
 import 'core/global.dart';
 
 void main() async {
@@ -38,6 +39,8 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
         useMaterial3: true,
       ),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       initialRoute: '/',
       onGenerateRoute: AppRouter(this.context).generate,
     );


### PR DESCRIPTION
## Summary
- register localization delegates in `MaterialApp`

## Testing
- `bash codex_dev.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3ef6007883228e5711014e330e2d